### PR TITLE
Integrate with vimrc plugin

### DIFF
--- a/plugin/snipMate_drupal.vim
+++ b/plugin/snipMate_drupal.vim
@@ -25,9 +25,7 @@ if has("autocmd")
     autocmd BufRead,BufNewFile *.profile set filetype=php
     autocmd BufRead,BufNewFile *.view set filetype=php
     autocmd BufRead,BufNewFile *.make set filetype=dmake
-    " This might need add-on ini parsing support, but at
-    " minimum it makes ini-drupal.snippets work.
-    autocmd BufRead,BufNewFile *.info set filetype=ini
+    autocmd BufRead,BufNewFile *.info set filetype=drini
   augroup END
 endif
 " vim:noet:sw=4:ts=4:ft=vim


### PR DESCRIPTION

The drupal vimrc plugin uses a "drini.drupal" file type as mentioned here:

https://www.drupal.org/node/2845607#comment-12069352.

This change sets that instead of using the ini filetype.